### PR TITLE
Fixed Add BDT entry error

### DIFF
--- a/BACnetServerExample/BACnetServerExample.cpp
+++ b/BACnetServerExample/BACnetServerExample.cpp
@@ -578,6 +578,13 @@ int main(int argc, char** argv)
 	fpSetPropertyEnabled(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_NETWORK_PORT, g_database.networkPort.instance, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_BBMD_BROADCAST_DISTRIBUTION_TABLE, true);
 	fpSetPropertyEnabled(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_NETWORK_PORT, g_database.networkPort.instance, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_BBMD_FOREIGN_DEVICE_TABLE, true);
 
+	uint8_t ipPortConcat[6];
+	memcpy(ipPortConcat, g_database.networkPort.IPAddress, 4);
+	ipPortConcat[4] = g_database.networkPort.BACnetIPUDPPort / 256;
+	ipPortConcat[5] = g_database.networkPort.BACnetIPUDPPort % 256;
+	fpAddBDTEntry(ipPortConcat, 6, g_database.networkPort.IPSubnetMask, 4);		// First BDT Entry must be server device
+	fpSetBBMD(g_database.device.instance, g_database.networkPort.instance);
+
 	std::cout << "OK" << std::endl;
 	
 	// 5. Send I-Am of this device
@@ -692,7 +699,6 @@ bool DoUserInput()
 			
 		fpAddBDTEntry(bbmdIpAddress, 6, bbmdIpMask, 4);
 		fpSetBBMD(g_database.device.instance, g_database.networkPort.instance);
-
 		break;
 	}
 	case 'i': {
@@ -768,6 +774,7 @@ bool DoUserInput()
 		std::cout << "https://github.com/chipkin/BACnetServerExampleCPP" << std::endl << std::endl;
 
 		std::cout << "Help:" << std::endl;
+		std::cout << "b - Add (B)roadcast Distribution Table entry" << std::endl;
 		std::cout << "i - (i)ncrement Analog Value: " << g_database.analogValue.instance << " by 1.1" << std::endl;
 		std::cout << "r - Toggle the Analog Input: 0 (r)eliability status" << std::endl;
 		std::cout << "f - Send Register (foreign) device message" << std::endl;

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ For the example server to run properly, please enable all object types and featu
 ## Example Output
 
 ```txt
-CAS BACnet Stack Server Example v0.0.13.0
+CAS BACnet Stack Server Example v0.0.14.0
 https://github.com/chipkin/BACnetServerExampleCPP
 
 FYI: Default to use device instance= 389999
 FYI: Loading CAS BACnet Stack functions... OK
-FYI: CAS BACnet Stack version: 3.24.10.0
+FYI: CAS BACnet Stack version: 3.26.1.0
 FYI: Connecting UDP Resource to port=[47808]... OK, Connected to port
 FYI: Registering the Callback Functions with the CAS BACnet Stack
 Setting up server device. device.instance=[389999]


### PR DESCRIPTION
Added missing first BDT entry (server device has to be the first BDT entry). BDT entry added using network imformation loaded from system calls during database object creation.