### PR TITLE
Added Example for DateTimeValue Object + Release prep

### DIFF
--- a/BACnetServerExample/BACnetServerExample.cpp
+++ b/BACnetServerExample/BACnetServerExample.cpp
@@ -583,7 +583,6 @@ int main(int argc, char** argv)
 	ipPortConcat[4] = g_database.networkPort.BACnetIPUDPPort / 256;
 	ipPortConcat[5] = g_database.networkPort.BACnetIPUDPPort % 256;
 	fpAddBDTEntry(ipPortConcat, 6, g_database.networkPort.IPSubnetMask, 4);		// First BDT Entry must be server device
-	fpSetBBMD(g_database.device.instance, g_database.networkPort.instance);
 
 	std::cout << "OK" << std::endl;
 

--- a/BACnetServerExample/BACnetServerExample.cpp
+++ b/BACnetServerExample/BACnetServerExample.cpp
@@ -586,7 +586,16 @@ int main(int argc, char** argv)
 	fpSetBBMD(g_database.device.instance, g_database.networkPort.instance);
 
 	std::cout << "OK" << std::endl;
+
+	// Add the DateTimeValue Object
+	std::cout << "Added DateTimeValue. dateTimeValue.instance=[" << g_database.dateTimeValue.instance << "]... ";
+	if (!fpAddObject(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_DATETIME_VALUE, g_database.dateTimeValue.instance)) {
+		std::cerr << "Failed to add DateTimeValue" << std::endl;
+		return -1;
+	}
 	
+	std::cout << "OK" << std::endl;
+
 	// 5. Send I-Am of this device
 	// ---------------------------------------------------------------------------
 	// To be a good citizen on a BACnet network. We should announce ourself when we start up. 
@@ -1116,6 +1125,17 @@ bool CallbackGetPropertyDate(const uint32_t deviceInstance, const uint16_t objec
 			return true;
 		}
 	}
+	// Example of DateTime Value Object Present Value property
+	if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_DATETIME_VALUE && objectInstance == 60) {
+			if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_PRESENT_VALUE) {
+				*year = g_database.dateTimeValue.presentValueYear;
+				*month = g_database.dateTimeValue.presentValueMonth;
+				*day = g_database.dateTimeValue.presentValueDay;
+				*weekday = g_database.dateTimeValue.presentValueWeekDay;
+				return true;
+			}
+	}
+
 	return false;
 }
 
@@ -1364,6 +1384,16 @@ bool CallbackGetPropertyTime(const uint32_t deviceInstance, const uint16_t objec
 			*hundrethSeconds = 0;
 			return true;
 		}
+	}
+	// Example of DateTime Value Object Present Value property
+	if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_DATETIME_VALUE && objectInstance == 60) {
+			if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_PRESENT_VALUE) {
+				*hour = g_database.dateTimeValue.presentValueHour;
+				*minute = g_database.dateTimeValue.presentValueMinute;
+				*second = g_database.dateTimeValue.presentValueSecond;
+				*hundrethSeconds = g_database.dateTimeValue.presentValueHundredthSeconds;
+				return true;
+			}
 	}
 	return false;
 }
@@ -2006,6 +2036,16 @@ bool GetObjectName(const uint32_t deviceInstance, const uint16_t objectType, con
 			return false;
 		}
 		memcpy(value, g_database.networkPort.objectName.c_str(), stringSize);
+		*valueElementCount = (uint32_t) stringSize;
+		return true;
+	}
+	else if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_DATETIME_VALUE && objectInstance == g_database.dateTimeValue.instance) {
+		stringSize = g_database.dateTimeValue.objectName.size();
+		if (stringSize > maxElementCount) {
+			std::cerr << "Error - not enough space to store full name of objectType=[" << objectType << "], objectInstance=[" << objectInstance <<" ]" << std::endl;
+			return false;
+		}
+		memcpy(value, g_database.dateTimeValue.objectName.c_str(), stringSize);
 		*valueElementCount = (uint32_t) stringSize;
 		return true;
 	}

--- a/BACnetServerExample/BACnetServerExample.cpp
+++ b/BACnetServerExample/BACnetServerExample.cpp
@@ -578,6 +578,13 @@ int main(int argc, char** argv)
 	fpSetPropertyEnabled(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_NETWORK_PORT, g_database.networkPort.instance, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_BBMD_BROADCAST_DISTRIBUTION_TABLE, true);
 	fpSetPropertyEnabled(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_NETWORK_PORT, g_database.networkPort.instance, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_BBMD_FOREIGN_DEVICE_TABLE, true);
 
+	uint8_t ipPortConcat[6];
+	memcpy(ipPortConcat, g_database.networkPort.IPAddress, 4);
+	ipPortConcat[4] = g_database.networkPort.BACnetIPUDPPort / 256;
+	ipPortConcat[5] = g_database.networkPort.BACnetIPUDPPort % 256;
+	fpAddBDTEntry(ipPortConcat, 6, g_database.networkPort.IPSubnetMask, 4);		// First BDT Entry must be server device
+	fpSetBBMD(g_database.device.instance, g_database.networkPort.instance);
+
 	std::cout << "OK" << std::endl;
 	
 	// 5. Send I-Am of this device
@@ -692,7 +699,6 @@ bool DoUserInput()
 			
 		fpAddBDTEntry(bbmdIpAddress, 6, bbmdIpMask, 4);
 		fpSetBBMD(g_database.device.instance, g_database.networkPort.instance);
-
 		break;
 	}
 	case 'i': {
@@ -768,6 +774,7 @@ bool DoUserInput()
 		std::cout << "https://github.com/chipkin/BACnetServerExampleCPP" << std::endl << std::endl;
 
 		std::cout << "Help:" << std::endl;
+		std::cout << "b - Add (B)roadcast Distribution Table entry" << std::endl;
 		std::cout << "i - (i)ncrement Analog Value: " << g_database.analogValue.instance << " by 1.1" << std::endl;
 		std::cout << "r - Toggle the Analog Input: 0 (r)eliability status" << std::endl;
 		std::cout << "f - Send Register (foreign) device message" << std::endl;

--- a/BACnetServerExample/CASBACnetStackExampleConstants.h
+++ b/BACnetServerExample/CASBACnetStackExampleConstants.h
@@ -71,7 +71,7 @@ public:
 	//static const uint16_t OBJECT_TYPE_DATEPATTERN_VALUE = 41;
 	static const uint16_t OBJECT_TYPE_DATE_VALUE = 42;
 	//static const uint16_t OBJECT_TYPE_DATETIMEPATTERN_VALUE = 43;
-	//static const uint16_t OBJECT_TYPE_DATETIME_VALUE = 44;
+	static const uint16_t OBJECT_TYPE_DATETIME_VALUE = 44;
 	static const uint16_t OBJECT_TYPE_INTEGER_VALUE = 45;
 	static const uint16_t OBJECT_TYPE_LARGE_ANALOG_VALUE = 46;
 	static const uint16_t OBJECT_TYPE_OCTETSTRING_VALUE = 47;

--- a/BACnetServerExample/CASBACnetStackExampleDatabase.cpp
+++ b/BACnetServerExample/CASBACnetStackExampleDatabase.cpp
@@ -167,6 +167,16 @@ void ExampleDatabase::Setup() {
 	this->networkPort.FdBbmdAddressHostIp[3] = 126;
 	this->networkPort.FdBbmdAddressPort = 47809;
 	this->networkPort.FdSubscriptionLifetime = 3600;
+	this->dateTimeValue.instance = 60;
+	this->dateTimeValue.objectName = "DateTimeValue " + ExampleDatabase::GetColorName();
+	this->dateTimeValue.presentValueYear = 122;
+	this->dateTimeValue.presentValueMonth = 1;
+	this->dateTimeValue.presentValueDay = 28;
+	this->dateTimeValue.presentValueWeekDay = 5;
+	this->dateTimeValue.presentValueHour = 16;
+	this->dateTimeValue.presentValueMinute = 53;
+	this->dateTimeValue.presentValueSecond = 47;
+	this->dateTimeValue.presentValueHundredthSeconds = 55;	
 	this->LoadNetworkPortProperties() ; 
 }
 

--- a/BACnetServerExample/CASBACnetStackExampleDatabase.h
+++ b/BACnetServerExample/CASBACnetStackExampleDatabase.h
@@ -249,6 +249,19 @@ struct CreatedAnalogValue {
 	}
 };
 
+class ExampleDatabaseDateTimeValue : public ExampleDatabaseBaseObject
+{
+	public:
+		uint8_t presentValueYear;
+		uint8_t presentValueMonth;
+		uint8_t presentValueDay;
+		uint8_t presentValueWeekDay;
+		uint8_t presentValueHour;
+		uint8_t presentValueMinute;
+		uint8_t presentValueSecond;
+		uint8_t presentValueHundredthSeconds;
+};
+
 class ExampleDatabase {
 
 	public:
@@ -273,6 +286,7 @@ class ExampleDatabase {
 		ExampleDatabasePositiveIntegerValue positiveIntegerValue;
 		ExampleDatabaseTimeValue timeValue;
 		ExampleDatabaseNetworkPort networkPort;
+		ExampleDatabaseDateTimeValue dateTimeValue;
 
 	// Storage for create objects
 	std::map<uint32_t, CreatedAnalogValue> CreatedAnalogValueData;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0.0.x
 
+### 0.0.15.x (2021-Jan-28)
+- Added DateTimeValue to example
+- Updated CAS BACnet Stack to version v3.27.0.0
+
 ### 0.0.14.x (2021-Jan-20)
 - Added LogDebugMessage callback to example
 - Updated CAS BACnet Stack to version v3.26.0.0

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ For the example server to run properly, please enable all object types and featu
 ## Example Output
 
 ```txt
-CAS BACnet Stack Server Example v0.0.13.0
+CAS BACnet Stack Server Example v0.0.14.0
 https://github.com/chipkin/BACnetServerExampleCPP
 
 FYI: Default to use device instance= 389999
 FYI: Loading CAS BACnet Stack functions... OK
-FYI: CAS BACnet Stack version: 3.24.10.0
+FYI: CAS BACnet Stack version: 3.26.1.0
 FYI: Connecting UDP Resource to port=[47808]... OK, Connected to port
 FYI: Registering the Callback Functions with the CAS BACnet Stack
 Setting up server device. device.instance=[389999]

--- a/README.md
+++ b/README.md
@@ -39,14 +39,17 @@ Pre-configured with the following example BACnet device and objects:
   - positive_integer_value: 48  (PositiveIntegerValue Turquoise)
   - time_value: 50  (TimeValue Umber)
   - NetworkPort: 56  (NetworkPort Vermilion)
+  - dateTimeValue: 60 (DateTimeValue White)
 
 The following keyboard commands can be issued in the server window:
 
-- **q**: Quit and exit the server
-- **i**: Increment the analog_value property Diamond by 1.1
-- **r**: Toggle the analog input reliability status
-- **f**: Send foreign device registration
-- **h**: Display help menu
+- **b**: Add (B)roadcast Distribution Table entry
+- **i**: (i)ncrement Analog Value: 2 by 1.1
+- **r**: Toggle the Analog Input: 0 (r)eliability status
+- **f**: Send Register (foreign) device message
+- **h**: (h)elp
+- **m**: Send text (m)essage
+- **q**: (q)uit
 
 ## Command arguments
 
@@ -63,12 +66,12 @@ For the example server to run properly, please enable all object types and featu
 ## Example Output
 
 ```txt
-CAS BACnet Stack Server Example v0.0.14.0
+CAS BACnet Stack Server Example v0.0.15.0
 https://github.com/chipkin/BACnetServerExampleCPP
 
 FYI: Default to use device instance= 389999
 FYI: Loading CAS BACnet Stack functions... OK
-FYI: CAS BACnet Stack version: 3.26.1.0
+FYI: CAS BACnet Stack version: 3.27.0.0
 FYI: Connecting UDP Resource to port=[47808]... OK, Connected to port
 FYI: Registering the Callback Functions with the CAS BACnet Stack
 Setting up server device. device.instance=[389999]


### PR DESCRIPTION
Modified the following:
- GetPropertyTime() and GetPropertyDate() callbacks
- GetObjectName()
- Added DateTimeValue object to example device
- Added DateTimeValue values to ExampleDatabase
- Bump Example version to 0.0.15

- Updated Readme for Example version 0.0.15 Release
- Force add host BDT Entry for BDT

The merge conflict is from the README, can just accept the new one.