### PR TITLE
Example v0.0.16

### DIFF
--- a/BACnetServerExample/BACnetServerExample.cpp
+++ b/BACnetServerExample/BACnetServerExample.cpp
@@ -2130,13 +2130,16 @@ bool CallbackReinitializeDevice(const uint32_t deviceInstance, const uint32_t re
 	// Before handling the reinitializedState, first check the password.
 	// If your device does not require a password, then ignore any password passed in.
 	// Otherwise, validate the password.
-	//		If password invalid: set errorCode to PasswordInvalid (26)
-	//		If password is required, but no password was provided: set errorCode to MissingRequiredParameter (16)
+	//		If password invalid, or a password is required, but no password was provided: set errorCode to PasswordInvalid (26)
 	// In this example, a password of 12345 is required.
+	
+	// Check if missing
 	if (password == NULL || passwordLength == 0) {
-		*errorCode = CASBACnetStackExampleConstants::ERROR_MISSING_REQUIRED_PARAMETER;
+		*errorCode = CASBACnetStackExampleConstants::ERROR_PASSWORD_FAILURE;
 		return false;
 	}
+
+	// Check if correct
 	if (strcmp(password, "12345") != 0) {
 		*errorCode = CASBACnetStackExampleConstants::ERROR_PASSWORD_FAILURE;
 		return false;

--- a/BACnetServerExample/BACnetServerExample.cpp
+++ b/BACnetServerExample/BACnetServerExample.cpp
@@ -375,6 +375,7 @@ int main(int argc, char** argv)
 	fpSetProprietaryProperty(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_ANALOG_INPUT, g_database.analogInput.instance, 512 + 1, false, false, CASBACnetStackExampleConstants::DATA_TYPE_CHARACTER_STRING, false, false, false);
 	fpSetProprietaryProperty(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_ANALOG_INPUT, g_database.analogInput.instance, 512 + 2, true, false, CASBACnetStackExampleConstants::DATA_TYPE_CHARACTER_STRING, false, false, false);
 	fpSetProprietaryProperty(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_ANALOG_INPUT, g_database.analogInput.instance, 512 + 3, true, true, CASBACnetStackExampleConstants::DATA_TYPE_CHARACTER_STRING, false, false, false);
+	fpSetProprietaryProperty(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_ANALOG_INPUT, g_database.analogInput.instance, 512 + 4, false, false, CASBACnetStackExampleConstants::DATA_TYPE_DATETIME, false, false, false);
 
 	// Set the Present value to subscribable 
 	fpSetPropertySubscribable(g_database.device.instance, CASBACnetStackExampleConstants::OBJECT_TYPE_ANALOG_INPUT, g_database.analogInput.instance, CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_PRESENT_VALUE, true);
@@ -1103,7 +1104,7 @@ bool CallbackGetPropertyCharString(const uint32_t deviceInstance, const uint16_t
 // Callback used by the BACnet Stack to get Date property values from the user
 bool CallbackGetPropertyDate(const uint32_t deviceInstance, const uint16_t objectType, const uint32_t objectInstance, const uint32_t propertyIdentifier, uint8_t* year, uint8_t* month, uint8_t* day, uint8_t* weekday, const bool useArrayIndex, const uint32_t propertyArrayIndex)
 {
-	// Example of Date Value Object Present Value property
+	// Example of getting Date Value Object Present Value property
 	if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_PRESENT_VALUE) {
 		if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_DATE_VALUE && objectInstance == g_database.dateValue.instance) {
 			*year = g_database.dateValue.presentValueYear;
@@ -1113,7 +1114,7 @@ bool CallbackGetPropertyDate(const uint32_t deviceInstance, const uint16_t objec
 			return true;
 		}
 	}
-	// Example of Device Local Date property
+	// Example of getting Device Local Date property
 	else if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_LOCAL_DATE) {
 		if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_DEVICE && objectInstance == g_database.device.instance) {
 			time_t adjustedTime = time(0) - g_database.device.currentTimeOffset;
@@ -1125,15 +1126,25 @@ bool CallbackGetPropertyDate(const uint32_t deviceInstance, const uint16_t objec
 			return true;
 		}
 	}
-	// Example of DateTime Value Object Present Value property
+	// Example of getting DateTime Value Object Present Value property
 	if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_DATETIME_VALUE && objectInstance == 60) {
-			if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_PRESENT_VALUE) {
-				*year = g_database.dateTimeValue.presentValueYear;
-				*month = g_database.dateTimeValue.presentValueMonth;
-				*day = g_database.dateTimeValue.presentValueDay;
-				*weekday = g_database.dateTimeValue.presentValueWeekDay;
-				return true;
+		if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_PRESENT_VALUE) {
+			*year = g_database.dateTimeValue.presentValueYear;
+			*month = g_database.dateTimeValue.presentValueMonth;
+			*day = g_database.dateTimeValue.presentValueDay;
+			*weekday = g_database.dateTimeValue.presentValueWeekDay;
+			return true;
 			}
+	}
+	// Example of getting Analog Input object Date Time Proprietary property
+	if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_ANALOG_INPUT && objectInstance == g_database.analogInput.instance) {
+		if (propertyIdentifier == 512 + 4) {
+			*year = g_database.analogInput.proprietaryYear;
+			*month = g_database.analogInput.proprietaryMonth;
+			*day = g_database.analogInput.proprietaryDay;
+			*weekday = g_database.analogInput.proprietaryWeekDay;
+			return true;
+		}
 	}
 
 	return false;
@@ -1363,7 +1374,7 @@ bool CallbackGetPropertyReal(uint32_t deviceInstance, uint16_t objectType, uint3
 // Callback used by the BACnet Stack to get Time property values from the user
 bool CallbackGetPropertyTime(const uint32_t deviceInstance, const uint16_t objectType, const uint32_t objectInstance, const uint32_t propertyIdentifier, uint8_t* hour, uint8_t* minute, uint8_t* second, uint8_t* hundrethSeconds, const bool useArrayIndex, const uint32_t propertyArrayIndex)
 {
-	// Example of Time Value Object Present Value property
+	// Example of getting Time Value Object Present Value property
 	if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_PRESENT_VALUE) {
 		if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_TIME_VALUE && objectInstance == g_database.timeValue.instance) {
 			*hour = g_database.timeValue.presentValueHour;
@@ -1373,7 +1384,7 @@ bool CallbackGetPropertyTime(const uint32_t deviceInstance, const uint16_t objec
 			return true;
 		}
 	}
-	// Example of Device Local Time property
+	// Example of getting Device Local Time property
 	else if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_LOCAL_TIME) {
 		if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_DEVICE && objectInstance == g_database.device.instance) {
 			time_t adjustedTime = time(0) - g_database.device.currentTimeOffset;
@@ -1385,16 +1396,27 @@ bool CallbackGetPropertyTime(const uint32_t deviceInstance, const uint16_t objec
 			return true;
 		}
 	}
-	// Example of DateTime Value Object Present Value property
+	// Example of getting DateTime Value Object Present Value property
 	if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_DATETIME_VALUE && objectInstance == 60) {
 			if (propertyIdentifier == CASBACnetStackExampleConstants::PROPERTY_IDENTIFIER_PRESENT_VALUE) {
-				*hour = g_database.dateTimeValue.presentValueHour;
-				*minute = g_database.dateTimeValue.presentValueMinute;
-				*second = g_database.dateTimeValue.presentValueSecond;
-				*hundrethSeconds = g_database.dateTimeValue.presentValueHundredthSeconds;
-				return true;
+			*hour = g_database.dateTimeValue.presentValueHour;
+			*minute = g_database.dateTimeValue.presentValueMinute;
+			*second = g_database.dateTimeValue.presentValueSecond;
+			*hundrethSeconds = g_database.dateTimeValue.presentValueHundredthSeconds;
+			return true;
 			}
 	}
+	// Example of getting Analog Input object DateTime Proprietary property
+	if (objectType == CASBACnetStackExampleConstants::OBJECT_TYPE_ANALOG_INPUT && objectInstance == g_database.analogInput.instance) {
+		if (propertyIdentifier == 512 + 4) {
+			*hour = g_database.analogInput.proprietaryHour;
+			*minute = g_database.analogInput.proprietaryMinute;
+			*second = g_database.analogInput.proprietarySecond;
+			*hundrethSeconds = g_database.analogInput.proprietaryHundredthSeconds;
+			return true;
+		}
+	}
+
 	return false;
 }
 

--- a/BACnetServerExample/BACnetServerExample.cpp
+++ b/BACnetServerExample/BACnetServerExample.cpp
@@ -60,7 +60,7 @@ ExampleDatabase g_database; // The example database that stores current values.
 
 // Constants
 // =======================================
-const std::string APPLICATION_VERSION = "0.0.14";  // See CHANGELOG.md for a full list of changes.
+const std::string APPLICATION_VERSION = "0.0.16";  // See CHANGELOG.md for a full list of changes.
 const uint32_t MAX_RENDER_BUFFER_LENGTH = 1024 * 20;
 
 

--- a/BACnetServerExample/BACnetServerExample.cpp
+++ b/BACnetServerExample/BACnetServerExample.cpp
@@ -2130,16 +2130,14 @@ bool CallbackReinitializeDevice(const uint32_t deviceInstance, const uint32_t re
 	// Before handling the reinitializedState, first check the password.
 	// If your device does not require a password, then ignore any password passed in.
 	// Otherwise, validate the password.
-	//		If password invalid, or a password is required, but no password was provided: set errorCode to PasswordInvalid (26)
+	//		If password invalid, missing, or incorrect: set errorCode to PasswordInvalid (26)
 	// In this example, a password of 12345 is required.
 	
-	// Check if missing
 	if (password == NULL || passwordLength == 0) {
 		*errorCode = CASBACnetStackExampleConstants::ERROR_PASSWORD_FAILURE;
 		return false;
 	}
 
-	// Check if correct
 	if (strcmp(password, "12345") != 0) {
 		*errorCode = CASBACnetStackExampleConstants::ERROR_PASSWORD_FAILURE;
 		return false;
@@ -2182,13 +2180,13 @@ bool CallbackDeviceCommunicationControl(const uint32_t deviceInstance, const uin
 	// To handle the password:
 	// If your device does not require a password, then ignore any password passed in.
 	// Otherwise, validate the password.
-	//		If password invalid: set errorCode to PasswordInvalid (26)
-	//		If password is required, but no password was provided: set errorCode to MissingRequiredParameter (16)
+	//		If password invalid, missing, or incorrect: set errorCode to PasswordInvalid (26)
 	// In this example, a password of 12345 is required.
 	if (password == NULL || passwordLength == 0) {
-		*errorCode = CASBACnetStackExampleConstants::ERROR_MISSING_REQUIRED_PARAMETER;
+		*errorCode = CASBACnetStackExampleConstants::ERROR_PASSWORD_FAILURE;
 		return false;
 	}
+
 	if (strcmp(password, "12345") != 0) {
 		*errorCode = CASBACnetStackExampleConstants::ERROR_PASSWORD_FAILURE;
 		return false;

--- a/BACnetServerExample/CASBACnetStackExampleConstants.h
+++ b/BACnetServerExample/CASBACnetStackExampleConstants.h
@@ -188,6 +188,7 @@ public:
 	static const uint32_t DATA_TYPE_DATE = 10;
 	static const uint32_t DATA_TYPE_TIME = 11;
 	static const uint32_t DATA_TYPE_BACNET_OBJECT_IDENTIFIER = 12;
+	static const uint32_t DATA_TYPE_DATETIME = 27;
 
 	// Reinitialized State
 	static const uint8_t REINITIALIZED_STATE_WARM_START = 1;

--- a/BACnetServerExample/CASBACnetStackExampleDatabase.cpp
+++ b/BACnetServerExample/CASBACnetStackExampleDatabase.cpp
@@ -91,6 +91,14 @@ void ExampleDatabase::Setup() {
 	this->analogInput.presentValue = 1.001f;
 	this->analogInput.covIncurment = 2.0f; 
 	this->analogInput.reliability = 0; // no-fault-detected (0), unreliable-other (7)
+	this->analogInput.proprietaryYear = 122;
+	this->analogInput.proprietaryMonth = 3;
+	this->analogInput.proprietaryDay = 20;
+	this->analogInput.proprietaryWeekDay = 7;
+	this->analogInput.proprietaryHour = 12;
+	this->analogInput.proprietaryMinute = 23;
+	this->analogInput.proprietarySecond = 58;
+	this->analogInput.proprietaryHundredthSeconds = 55;
 	this->analogOutput.instance = 1;
 	this->analogOutput.objectName = "AnalogOutput " + ExampleDatabase::GetColorName();
 	this->analogValue.instance = 2;

--- a/BACnetServerExample/CASBACnetStackExampleDatabase.h
+++ b/BACnetServerExample/CASBACnetStackExampleDatabase.h
@@ -44,6 +44,16 @@ class ExampleDatabaseAnalogInput : public ExampleDatabaseBaseObject
 		float covIncurment; 
 		uint32_t reliability;
 		std::string description; // This is an optional property that has been enabled.  
+
+		// DateTime Proprietary Value
+		uint8_t proprietaryYear;
+		uint8_t proprietaryMonth;
+		uint8_t proprietaryDay;
+		uint8_t proprietaryWeekDay;
+		uint8_t proprietaryHour;
+		uint8_t proprietaryMinute;
+		uint8_t proprietarySecond;
+		uint8_t proprietaryHundredthSeconds;
 };
 
 class ExampleDatabaseAnalogOutput : public ExampleDatabaseBaseObject 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,19 @@
 
 ## Version 0.0.x
 
-### 0.0.15.x (2021-Jan-28)
+### 0.0.16.x (2022-Mar-07)
+- Added read-only DateTime proprietary property to analog input
+- Updated CAS BACnet Stack to version v3.29.0.0
+
+### 0.0.15.x (2022-Jan-28)
 - Added DateTimeValue to example
 - Updated CAS BACnet Stack to version v3.27.0.0
 
-### 0.0.14.x (2021-Jan-20)
+### 0.0.14.x (2022-Jan-20)
 - Added LogDebugMessage callback to example
 - Updated CAS BACnet Stack to version v3.26.0.0
 
-### 0.0.13.x (2021-Jan-14)
+### 0.0.13.x (2022-Jan-14)
 - Added BroadcastDistributionTable to example
 
 ### 0.0.12.x (2021-Dec-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 0.0.16.x (2022-Mar-07)
 - Added read-only DateTime proprietary property to analog input
+- Updated ReinitializeDevice password check errorCode
 - Updated CAS BACnet Stack to version v3.29.0.0
 
 ### 0.0.15.x (2022-Jan-28)


### PR DESCRIPTION
- Added an example of a read-only DateTime proprietary property to the analogInput object
- Updated errorCode when password is not provided when a password is required in ReinitializeDevice to adhere to latest BACnet spec